### PR TITLE
Feature/automotive test

### DIFF
--- a/36-automotive
+++ b/36-automotive
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+. test.common
+
+test_start "ptp4l with Automotive Profile"
+
+nodes=3
+max_sync_time=100
+
+# Automotive Profile options carried over from gPTP, common between master and slaves
+common_confs="
+gmCapable		1
+priority1		248
+priority2		248
+logSyncInterval		-3
+syncReceiptTimeout	3
+neighborPropDelayThresh	800
+min_neighbor_prop_delay	-20000000
+assume_two_step		1
+path_trace_enabled	1
+follow_up_info		1
+transportSpecific	0x1
+ptp_dst_mac		01:80:C2:00:00:0E
+inhibit_announce	1
+
+BMCA			noop
+inhibit_announce	1
+asCapable		true
+"
+
+# Options not added.
+# network_transport	L2	# The default is UDPv4. clknetsim does not support L2.
+# delay_mechanism	P2P	# The default is E2E. Does clknetsim not support P2P?
+
+# Automotive Profile Master specific options
+master_conf="$common_confs
+masterOnly		1
+inhibit_delay_req	1
+"
+
+# Automotive Profile Slave specific options
+slave_conf="$common_confs
+slaveOnly			1
+ignore_source_id		1
+
+step_threshold			1
+operLogSyncInterval		0
+operLogPdelayReqInterval	2
+msg_interval_request		1
+servo_offset_threshold		30
+servo_num_offset_values		10
+"
+
+run_ptp4l || test_fail
+check_sync || test_fail
+
+test_pass

--- a/36-automotive
+++ b/36-automotive
@@ -29,9 +29,8 @@ inhibit_announce	1
 asCapable		true
 "
 
-# Options not added.
+# Option not added.
 # network_transport	L2	# The default is UDPv4. clknetsim does not support L2.
-# delay_mechanism	P2P	# The default is E2E. Does clknetsim not support P2P?
 
 # Automotive Profile Master specific options
 master_conf="$common_confs

--- a/36-automotive
+++ b/36-automotive
@@ -4,7 +4,7 @@
 
 test_start "ptp4l with Automotive Profile"
 
-nodes=3
+nodes=2
 max_sync_time=100
 
 # Automotive Profile options carried over from gPTP, common between master and slaves
@@ -22,6 +22,7 @@ follow_up_info		1
 transportSpecific	0x1
 ptp_dst_mac		01:80:C2:00:00:0E
 inhibit_announce	1
+delay_mechanism		P2P
 
 BMCA			noop
 inhibit_announce	1


### PR DESCRIPTION
Solves #13 

This adds a test using the configurations from the automotive profile, as can be found in [automotive-master.cfg](https://github.com/richardcochran/linuxptp/blob/master/configs/automotive-master.cfg) and [automotive-slave.cfg](https://github.com/richardcochran/linuxptp/blob/master/configs/automotive-slave.cfg).

One configuration has been omitted:
* `network_transport L2` - The default is UDPv4. clknetsim does not support L2.