### PR TITLE
AWK math replace power with posix standard

### DIFF
--- a/11-syncinterval
+++ b/11-syncinterval
@@ -9,7 +9,7 @@ max_sync_time=320
 for i in $(seq -4 2 4); do
 	update_interval=$i
 	master_conf="logSyncInterval $i"
-	freq_max_limit=$(awk 'BEGIN {print 2e-6 / (2**'$i')**0.5}')
+	freq_max_limit=$(awk 'BEGIN {print 2e-6 / (2^'$i')^0.5}')
 	run_ptp4l || test_fail
 	check_sync || test_fail
 done

--- a/17-piservo
+++ b/17-piservo
@@ -11,8 +11,8 @@ max_sync_time=2000
 for jitter in 1e-8 1e-7 1e-6 1e-5; do
 	kp=$(awk 'BEGIN {x=1.5 / sqrt('$jitter'/'$wander'); print x < 0.7 ? x : 0.7}')
 	ki=$(awk 'BEGIN {x=1.2 / ('$jitter'/'$wander'); print x < 0.3 ? x : 0.3}')
-	time_rms_limit=$(awk 'BEGIN {print 1.5e-8 * ('$jitter'/1e-8)**0.75}')
-	freq_rms_limit=$(awk 'BEGIN {print 1.5e-8 * ('$jitter'/1e-8)**0.5}')
+	time_rms_limit=$(awk 'BEGIN {print 1.5e-8 * ('$jitter'/1e-8)^0.75}')
+	freq_rms_limit=$(awk 'BEGIN {print 1.5e-8 * ('$jitter'/1e-8)^0.5}')
 	time_max_limit=$(awk 'BEGIN {print 8 * '$time_rms_limit'}')
 	freq_max_limit=$(awk 'BEGIN {print 8 * '$freq_rms_limit'}')
 


### PR DESCRIPTION
Replaces GNU AWK's `**` syntax with the POSIX standard `^` for taking the power of a number.

Related:
- Solves #15 